### PR TITLE
G3: Add the ability for call recording

### DIFF
--- a/overlay/packages/apps/Dialer/res/values/config.xml
+++ b/overlay/packages/apps/Dialer/res/values/config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright (C) 2015 The CyanogenMod Project
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+    <bool name="call_recording_enabled">true</bool>
+</resources>


### PR DESCRIPTION
The initial overlay that adds the ability was missing, Fixit.
It doesn't override the location overlays, it's just adding
the ability where call recording in permitted.

Change-Id: I4bced7f4061fade193e2d346ad2e9cd15400188d
