### PR TITLE
g3-common: decommonize NFC config and HCE permission

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -85,9 +85,6 @@ EXTENDED_FONT_FOOTPRINT := true
 # Lights
 TARGET_PROVIDES_LIBLIGHT := true
 
-# NFC
-BOARD_NFC_CHIPSET := pn547
-
 # Offmode Charging
 COMMON_GLOBAL_CFLAGS += \
     -DBOARD_CHARGING_CMDLINE_NAME='"androidboot.mode"' \

--- a/g3.mk
+++ b/g3.mk
@@ -29,7 +29,6 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.camera.front.xml:system/etc/permissions/android.hardware.camera.front.xml \
     frameworks/native/data/etc/android.hardware.ethernet.xml:system/etc/permissions/android.hardware.ethernet.xml \
     frameworks/native/data/etc/android.hardware.location.gps.xml:system/etc/permissions/android.hardware.location.gps.xml \
-    frameworks/native/data/etc/android.hardware.nfc.hce.xml:system/etc/permissions/android.hardware.nfc.hce.xml \
     frameworks/native/data/etc/android.hardware.nfc.xml:system/etc/permissions/android.hardware.nfc.xml \
     frameworks/native/data/etc/android.hardware.sensor.barometer.xml:system/etc/permissions/android.hardware.sensor.barometer.xml \
     frameworks/native/data/etc/android.hardware.sensor.gyroscope.xml:system/etc/permissions/android.hardware.sensor.gyroscope.xml \
@@ -145,8 +144,6 @@ PRODUCT_COPY_FILES += \
 # NFC
 PRODUCT_PACKAGES += \
     com.android.nfc_extras \
-    NfcNci \
-    nfc_nci.pn54x.default \
     Tag
 
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
- The ls990 uses a pn544 instead of a pn547 so move BOARD_NFC_CHIPSET
  to the device folders
- Since the pn544 doesn't support HCE, move the permission for it
  to the device folders as well, otherwise, it will cause linker
  errors on the ls990
- Move NFC HALs to device repos since they don't work on pn544

Change-Id: I847ef9b75755ad651be0f7032a3a1fca9063a122
