### PR TITLE
ril: clean up this mess

### DIFF
--- a/system_prop.mk
+++ b/system_prop.mk
@@ -57,7 +57,8 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.radio.add_power_save=1 \
     persist.radio.apm_sim_not_pwdn=1 \
-    ro.telephony.ril_class=LgeLteRIL \
+    ro.ril.telephony.mqanelements=5 \
+    ro.telephony.ril_class=LgeLteRIL
 
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.data.netmgrd.qos.enable=false \


### PR DESCRIPTION
- Almost this entire class can go away now, especially since it's breaking
  our GSM brethren.
- Encapsulate the hacks that we do need in oldRilFeature props that we can set
  at the variant level.
- Move mQANElements to using a prop mQANElements

Change-Id: I25f6094cabf39306bf7e2c70b4a9f4d160cbe3d4
