### PR TITLE
init: use LD_SHIM_LIBS instead of polluting the global library loads

### DIFF
--- a/rootdir/etc/init.g3.rc
+++ b/rootdir/etc/init.g3.rc
@@ -12,7 +12,7 @@ on early-init
     write /sys/block/mmcblk1/bdi/read_ahead_kb 512
 
 on init
-    export LD_PRELOAD "/system/lib/libboringssl-compat.so:/system/lib/liblge.so"
+    export LD_SHIM_LIBS /system/vendor/lib/libmmqjpeg_codec.so|libboringssl-compat.so:/system/vendor/lib/libOpenCL.so|libboringssl-compat.so:/system/lib/libril.so|liblge.so
 
     mkdir /persist 0771 system system
 


### PR DESCRIPTION
Change-Id: I85701cbc64cf29195bba00b810b68f7d49ab8b99
