### PR TITLE
g3: Temporarily disable hw avc decoder

### DIFF
--- a/configs/media_codecs.xml
+++ b/configs/media_codecs.xml
@@ -102,7 +102,7 @@
     </Encoders>
 
     <Decoders>
-        <!-- Video Hardware  -->
+        <!-- Video Hardware
         <MediaCodec name="OMX.qcom.video.decoder.avc" type="video/avc" >
             <Quirk name="requires-allocate-on-input-ports" />
             <Quirk name="requires-allocate-on-output-ports" />
@@ -125,7 +125,7 @@
             <Feature name="adaptive-playback" />
             <Feature name="secure-playback" required="true" />
             <Limit name="concurrent-instances" max="4" />
-        </MediaCodec>
+        </MediaCodec> -->
         <MediaCodec name="OMX.qcom.video.decoder.mpeg2" type="video/mpeg2" >
             <Quirk name="requires-allocate-on-input-ports" />
             <Quirk name="requires-allocate-on-output-ports" />


### PR DESCRIPTION
The HW AVC decoder crashes. This causes Snap to force close and prevents the
playback of recorded videos (h264).
Use Google's software decoder, until we have fixed the crashes.

Change-Id: I4c104b51b1a08f45c8e97127619a95744567e0fb
